### PR TITLE
Use book title for annotations targetting urn:isbn:

### DIFF
--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -339,7 +339,8 @@ export default function Card({
       })()
     : null;
 
-  const isbn = pageUrl?.match(/^urn:isbn:(.+)$/i)?.[1].replace(/-/g, "");
+  const isbnMatch = pageUrl?.match(/^urn:isbn:(.+)$/i);
+  const isbn = isbnMatch ? isbnMatch[1].replace(/-/g, "") : null;
   const bookUrl = isbn ? `https://openlibrary.org/isbn/${isbn}` : null;
   const bookTitle =
     item.target?.title || item.title || (isbn ? `ISBN ${isbn}` : null);
@@ -348,6 +349,7 @@ export default function Card({
     const sel = item.target?.selector;
     if (!sel?.exact) return null;
     if (bookUrl) return bookUrl;
+    if (!pageUrl) return null;
     const prefix = sel.prefix ? encodeURIComponent(sel.prefix) + "-," : "";
     const suffix = sel.suffix ? ",-" + encodeURIComponent(sel.suffix) : "";
     return `${pageUrl}#:~:text=${prefix}${encodeURIComponent(sel.exact)}${suffix}`;

--- a/web/src/components/common/Card.tsx
+++ b/web/src/components/common/Card.tsx
@@ -21,6 +21,7 @@ import {
   Send,
   X,
   Bookmark,
+  BookOpen,
 } from "lucide-react";
 import ShareMenu from "../modals/ShareMenu";
 import AddToCollectionModal from "../modals/AddToCollectionModal";
@@ -338,6 +339,20 @@ export default function Card({
       })()
     : null;
 
+  const isbn = pageUrl?.match(/^urn:isbn:(.+)$/i)?.[1].replace(/-/g, "");
+  const bookUrl = isbn ? `https://openlibrary.org/isbn/${isbn}` : null;
+  const bookTitle =
+    item.target?.title || item.title || (isbn ? `ISBN ${isbn}` : null);
+
+  const quoteLinkUrl = (() => {
+    const sel = item.target?.selector;
+    if (!sel?.exact) return null;
+    if (bookUrl) return bookUrl;
+    const prefix = sel.prefix ? encodeURIComponent(sel.prefix) + "-," : "";
+    const suffix = sel.suffix ? ",-" + encodeURIComponent(sel.suffix) : "";
+    return `${pageUrl}#:~:text=${prefix}${encodeURIComponent(sel.exact)}${suffix}`;
+  })();
+
   const decodeHTMLEntities = (text: string) => {
     if (!text.includes("&")) return text;
     try {
@@ -549,14 +564,18 @@ export default function Card({
 
           {pageUrl && !isBookmark && !(contentWarning && !contentRevealed) && (
             <a
-              href={pageUrl}
+              href={bookUrl || pageUrl}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={(e) => handleExternalClick(e, pageUrl)}
+              onClick={(e) => handleExternalClick(e, bookUrl || pageUrl)}
               className="inline-flex items-center gap-1 text-xs text-primary-600 dark:text-primary-400 hover:underline mt-0.5 max-w-full"
             >
-              <ExternalLink size={10} className="flex-shrink-0" />
-              <span className="truncate">{displayUrl}</span>
+              {isbn ? (
+                <BookOpen size={10} className="flex-shrink-0" />
+              ) : (
+                <ExternalLink size={10} className="flex-shrink-0" />
+              )}
+              <span className="truncate">{isbn ? bookTitle : displayUrl}</span>
             </a>
           )}
         </div>
@@ -697,14 +716,11 @@ export default function Card({
               }
             >
               <a
-                href={`${pageUrl}#:~:text=${item.target.selector.prefix ? encodeURIComponent(item.target.selector.prefix) + "-," : ""}${encodeURIComponent(item.target.selector.exact)}${item.target.selector.suffix ? ",-" + encodeURIComponent(item.target.selector.suffix) : ""}`}
+                href={quoteLinkUrl || undefined}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={(e) => {
-                  const sel = item.target?.selector;
-                  if (!sel) return;
-                  const url = `${pageUrl}#:~:text=${sel.prefix ? encodeURIComponent(sel.prefix) + "-," : ""}${encodeURIComponent(sel.exact)}${sel.suffix ? ",-" + encodeURIComponent(sel.suffix) : ""}`;
-                  handleExternalClick(e, url);
+                  if (quoteLinkUrl) handleExternalClick(e, quoteLinkUrl);
                 }}
                 className="block break-words"
               >


### PR DESCRIPTION
If a book is being annotated (epub or physical) then the target.source will be `urn:isbn:…`.

URNs aren't useful for displaying within margin, so instead use the annotation's title & an open library url as the reference link.

Before:
<img width="694" height="252" alt="A highlight from a physical book showing a clickable link to urn:isbn:9780593983751" src="https://github.com/user-attachments/assets/9ba08e5f-c5de-4746-905f-3f60ed984d75" />

After:
<img width="791" height="337" alt="A highlight from a physical book showing a clickable link to There is no Antimemetics Division" src="https://github.com/user-attachments/assets/075152e2-94cf-4a56-b1e6-61a23368d1a0" />

<img width="592" height="327" alt="The you're about to leave Margin dialog, showing the openlibrary url being redirected to" src="https://github.com/user-attachments/assets/930c50d9-d8fb-449a-af99-1722baab2ae2" />
